### PR TITLE
add support for hub-of-hubs operator to watch owned resources

### DIFF
--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -36,10 +36,9 @@ RUN curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/s
     rm kubectl
 
 # install helm
-RUN curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 && \
-    chmod 700 get_helm.sh && \
-    VERIFY_CHECKSUM=false ./get_helm.sh && \
-    rm get_helm.sh
+RUN curl -L https://get.helm.sh/helm-v3.9.3-linux-amd64.tar.gz | tar xz && \
+    mv linux-amd64/helm /usr/local/bin/helm && \
+    rm -rf linux-amd64
 
 # install yq
 RUN curl -LO https://github.com/mikefarah/yq/releases/download/v4.25.3/yq_linux_amd64 && \

--- a/operator/bundle/manifests/hub-of-hubs-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/hub-of-hubs-operator.clusterserviceversion.yaml
@@ -522,7 +522,9 @@ spec:
           - create
           - delete
           - get
+          - list
           - update
+          - watch
         - apiGroups:
           - ""
           resources:
@@ -553,7 +555,9 @@ spec:
           - create
           - delete
           - get
+          - list
           - update
+          - watch
         - apiGroups:
           - ""
           resources:
@@ -562,7 +566,9 @@ spec:
           - create
           - delete
           - get
+          - list
           - update
+          - watch
         - apiGroups:
           - addon.open-cluster-management.io
           resources:
@@ -595,7 +601,9 @@ spec:
           - create
           - delete
           - get
+          - list
           - update
+          - watch
         - apiGroups:
           - batch
           resources:
@@ -656,7 +664,9 @@ spec:
           - create
           - delete
           - get
+          - list
           - update
+          - watch
         - apiGroups:
           - networking.k8s.io
           resources:
@@ -665,7 +675,9 @@ spec:
           - create
           - delete
           - get
+          - list
           - update
+          - watch
         - apiGroups:
           - operator.open-cluster-management.io
           resources:
@@ -710,6 +722,7 @@ spec:
           - get
           - list
           - update
+          - watch
         - apiGroups:
           - rbac.authorization.k8s.io
           resources:
@@ -720,6 +733,7 @@ spec:
           - get
           - list
           - update
+          - watch
         - apiGroups:
           - rbac.authorization.k8s.io
           resources:
@@ -728,7 +742,9 @@ spec:
           - create
           - delete
           - get
+          - list
           - update
+          - watch
         - apiGroups:
           - rbac.authorization.k8s.io
           resources:
@@ -737,7 +753,9 @@ spec:
           - create
           - delete
           - get
+          - list
           - update
+          - watch
         - apiGroups:
           - work.open-cluster-management.io
           resources:

--- a/operator/config/rbac/role.yaml
+++ b/operator/config/rbac/role.yaml
@@ -13,7 +13,9 @@ rules:
   - create
   - delete
   - get
+  - list
   - update
+  - watch
 - apiGroups:
   - ""
   resources:
@@ -44,7 +46,9 @@ rules:
   - create
   - delete
   - get
+  - list
   - update
+  - watch
 - apiGroups:
   - ""
   resources:
@@ -53,7 +57,9 @@ rules:
   - create
   - delete
   - get
+  - list
   - update
+  - watch
 - apiGroups:
   - addon.open-cluster-management.io
   resources:
@@ -86,7 +92,9 @@ rules:
   - create
   - delete
   - get
+  - list
   - update
+  - watch
 - apiGroups:
   - batch
   resources:
@@ -147,7 +155,9 @@ rules:
   - create
   - delete
   - get
+  - list
   - update
+  - watch
 - apiGroups:
   - networking.k8s.io
   resources:
@@ -156,7 +166,9 @@ rules:
   - create
   - delete
   - get
+  - list
   - update
+  - watch
 - apiGroups:
   - operator.open-cluster-management.io
   resources:
@@ -201,6 +213,7 @@ rules:
   - get
   - list
   - update
+  - watch
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:
@@ -211,6 +224,7 @@ rules:
   - get
   - list
   - update
+  - watch
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:
@@ -219,7 +233,9 @@ rules:
   - create
   - delete
   - get
+  - list
   - update
+  - watch
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:
@@ -228,7 +244,9 @@ rules:
   - create
   - delete
   - get
+  - list
   - update
+  - watch
 - apiGroups:
   - work.open-cluster-management.io
   resources:

--- a/operator/pkg/constants/constants.go
+++ b/operator/pkg/constants/constants.go
@@ -29,6 +29,7 @@ const (
 	LeafHubClusterAnnotationKey              = "hub-of-hubs.open-cluster-management.io/managed-by-hoh"
 	GlobalHubSkipConsoleInstallAnnotationKey = "globalhub.open-cluster-management.io/skip-console-install"
 	HoHOperatorOwnerLabelKey                 = "hub-of-hubs.open-cluster-management.io/managed-by"
+	HoHOperatorOwnerLabelVal                 = "multicluster-globalhub-operator"
 	HoHOperatorFinalizer                     = "hub-of-hubs.open-cluster-management.io/res-cleanup"
 
 	LeafHubClusterInstallHubLabelKey        = "globalhub.open-cluster-management.io/hub-install"

--- a/operator/pkg/controllers/leafhub/addon.go
+++ b/operator/pkg/controllers/leafhub/addon.go
@@ -33,8 +33,8 @@ import (
 )
 
 // applyClusterManagementAddon creates or updates ClusterManagementAddOn for hub-of-hubs
-func applyClusterManagementAddon(ctx context.Context, c client.Client, log logr.Logger, mghName string) error {
-	newHoHClusterManagementAddOn := buildClusterManagementAddon(mghName)
+func applyClusterManagementAddon(ctx context.Context, c client.Client, log logr.Logger) error {
+	newHoHClusterManagementAddOn := buildClusterManagementAddon()
 	existingHoHClusterManagementAddOn := &addonv1alpha1.ClusterManagementAddOn{}
 	if err := c.Get(ctx,
 		types.NamespacedName{
@@ -63,8 +63,8 @@ func applyClusterManagementAddon(ctx context.Context, c client.Client, log logr.
 }
 
 // deleteClusterManagementAddon deletes ClusterManagementAddOn for hub-of-hubs
-func deleteClusterManagementAddon(ctx context.Context, c client.Client, log logr.Logger, mghName string) error {
-	hohClusterManagementAddOn := buildClusterManagementAddon(mghName)
+func deleteClusterManagementAddon(ctx context.Context, c client.Client, log logr.Logger) error {
+	hohClusterManagementAddOn := buildClusterManagementAddon()
 	err := c.Delete(ctx, hohClusterManagementAddOn)
 	if err != nil && !errors.IsNotFound(err) {
 		log.Error(err, "failed to delete hoh clustermanagementaddon", "name", hohClusterManagementAddOn.GetName())
@@ -76,12 +76,12 @@ func deleteClusterManagementAddon(ctx context.Context, c client.Client, log logr
 }
 
 // buildClusterManagementAddon builds ClusterManagementAddOn resource for hub-of-hubs
-func buildClusterManagementAddon(mghName string) *addonv1alpha1.ClusterManagementAddOn {
+func buildClusterManagementAddon() *addonv1alpha1.ClusterManagementAddOn {
 	return &addonv1alpha1.ClusterManagementAddOn{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: constants.HoHClusterManagementAddonName,
 			Labels: map[string]string{
-				constants.HoHOperatorOwnerLabelKey: mghName,
+				constants.HoHOperatorOwnerLabelKey: constants.HoHOperatorOwnerLabelVal,
 			},
 		},
 		Spec: addonv1alpha1.ClusterManagementAddOnSpec{
@@ -94,10 +94,9 @@ func buildClusterManagementAddon(mghName string) *addonv1alpha1.ClusterManagemen
 }
 
 // applyManagedClusterAddon creates or updates ManagedClusterAddon for leafhubs
-func applyManagedClusterAddon(ctx context.Context, c client.Client, log logr.Logger, managedClusterName,
-	mghName string,
+func applyManagedClusterAddon(ctx context.Context, c client.Client, log logr.Logger, managedClusterName string,
 ) error {
-	newHoHManagedClusterAddon := buildManagedClusterAddon(managedClusterName, mghName)
+	newHoHManagedClusterAddon := buildManagedClusterAddon(managedClusterName)
 	existingHoHManagedClusterAddon := &addonv1alpha1.ManagedClusterAddOn{}
 	if err := c.Get(ctx,
 		types.NamespacedName{
@@ -139,10 +138,9 @@ func applyManagedClusterAddon(ctx context.Context, c client.Client, log logr.Log
 }
 
 // deleteManagedClusterAddon deletes ManagedClusterAddon for leafhubs
-func deleteManagedClusterAddon(ctx context.Context, c client.Client, log logr.Logger, managedClusterName,
-	mghName string,
+func deleteManagedClusterAddon(ctx context.Context, c client.Client, log logr.Logger, managedClusterName string,
 ) error {
-	hohManagedClusterAddon := buildManagedClusterAddon(managedClusterName, mghName)
+	hohManagedClusterAddon := buildManagedClusterAddon(managedClusterName)
 	err := c.Delete(ctx, hohManagedClusterAddon)
 	if err != nil && !errors.IsNotFound(err) {
 		log.Error(err, "failed to delete hoh managedclusteraddon", hohManagedClusterAddon.GetNamespace(),
@@ -156,13 +154,13 @@ func deleteManagedClusterAddon(ctx context.Context, c client.Client, log logr.Lo
 }
 
 // buildManagedClusterAddon builds ManagedClusterAddOn resource for given managedcluster
-func buildManagedClusterAddon(managedClusterName, mghName string) *addonv1alpha1.ManagedClusterAddOn {
+func buildManagedClusterAddon(managedClusterName string) *addonv1alpha1.ManagedClusterAddOn {
 	return &addonv1alpha1.ManagedClusterAddOn{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      constants.HoHManagedClusterAddonName,
 			Namespace: managedClusterName,
 			Labels: map[string]string{
-				constants.HoHOperatorOwnerLabelKey: mghName,
+				constants.HoHOperatorOwnerLabelKey: constants.HoHOperatorOwnerLabelVal,
 			},
 		},
 		Spec: addonv1alpha1.ManagedClusterAddOnSpec{

--- a/operator/pkg/controllers/leafhub/manifestwork.go
+++ b/operator/pkg/controllers/leafhub/manifestwork.go
@@ -106,10 +106,10 @@ func init() {
 }
 
 // applyHubSubWork creates or updates the subscription manifestwork for leafhub cluster
-func applyHubSubWork(ctx context.Context, c client.Client, log logr.Logger, mghName, managedClusterName string,
+func applyHubSubWork(ctx context.Context, c client.Client, log logr.Logger, managedClusterName string,
 	pm *packageManifestConfig,
 ) (*workv1.ManifestWork, error) {
-	desiredHubSubWork, err := buildHubSubWork(ctx, c, log, mghName, managedClusterName, pm)
+	desiredHubSubWork, err := buildHubSubWork(ctx, c, log, managedClusterName, pm)
 	if err != nil {
 		return nil, err
 	}
@@ -139,7 +139,7 @@ func applyHubSubWork(ctx context.Context, c client.Client, log logr.Logger, mghN
 		return nil, err
 	}
 	log.Info("existing packagemanifest", "packagemanifest", existingPM, "managedcluster", managedClusterName)
-	desiredHubSubWork, err = buildHubSubWork(ctx, c, log, mghName, managedClusterName, existingPM)
+	desiredHubSubWork, err = buildHubSubWork(ctx, c, log, managedClusterName, existingPM)
 	if err != nil {
 		return nil, err
 	}
@@ -162,7 +162,7 @@ func applyHubSubWork(ctx context.Context, c client.Client, log logr.Logger, mghN
 }
 
 // buildHubSubWork creates hub subscription manifestwork
-func buildHubSubWork(ctx context.Context, c client.Client, log logr.Logger, mghName, managedClusterName string,
+func buildHubSubWork(ctx context.Context, c client.Client, log logr.Logger, managedClusterName string,
 	pm *packageManifestConfig,
 ) (*workv1.ManifestWork, error) {
 	tpl, err := parseNonHypershiftTemplates(nonHypershiftManifestFS)
@@ -231,7 +231,7 @@ func buildHubSubWork(ctx context.Context, c client.Client, log logr.Logger, mghN
 				constants.HOHHubSubscriptionWorkSuffix),
 			Namespace: managedClusterName,
 			Labels: map[string]string{
-				constants.HoHOperatorOwnerLabelKey: mghName,
+				constants.HoHOperatorOwnerLabelKey: constants.HoHOperatorOwnerLabelVal,
 			},
 			Annotations: map[string]string{
 				// Add the postpone delete annotation for manifestwork so that the observabilityaddon can be
@@ -295,10 +295,10 @@ func getPackageManifestConfigFromHubSubWork(hubSubWork *workv1.ManifestWork) (*p
 }
 
 // applyHubMCHWork creates or updates the mch manifestwork for leafhub cluster
-func applyHubMCHWork(ctx context.Context, c client.Client, log logr.Logger, mghName,
+func applyHubMCHWork(ctx context.Context, c client.Client, log logr.Logger,
 	managedClusterName string,
 ) (*workv1.ManifestWork, error) {
-	desiredHubMCHWork, err := buildHubMCHWork(ctx, c, log, mghName, managedClusterName)
+	desiredHubMCHWork, err := buildHubMCHWork(ctx, c, log, managedClusterName)
 	if err != nil {
 		return nil, err
 	}
@@ -308,7 +308,7 @@ func applyHubMCHWork(ctx context.Context, c client.Client, log logr.Logger, mghN
 }
 
 // buildHubMCHWork creates hub MCH manifestwork
-func buildHubMCHWork(ctx context.Context, c client.Client, log logr.Logger, mghName,
+func buildHubMCHWork(ctx context.Context, c client.Client, log logr.Logger,
 	managedClusterName string,
 ) (*workv1.ManifestWork, error) {
 	tpl, err := parseNonHypershiftTemplates(nonHypershiftManifestFS)
@@ -368,7 +368,7 @@ func buildHubMCHWork(ctx context.Context, c client.Client, log logr.Logger, mghN
 			Name:      fmt.Sprintf("%s-%s", managedClusterName, constants.HoHHubMCHWorkSuffix),
 			Namespace: managedClusterName,
 			Labels: map[string]string{
-				constants.HoHOperatorOwnerLabelKey: mghName,
+				constants.HoHOperatorOwnerLabelKey: constants.HoHOperatorOwnerLabelVal,
 			},
 		},
 		Spec: workv1.ManifestWorkSpec{
@@ -547,7 +547,7 @@ func applyHubHypershiftWorks(ctx context.Context, c client.Client, log logr.Logg
 			Name:      fmt.Sprintf("%s-%s", managedClusterName, constants.HoHHostedHubWorkSuffix),
 			Namespace: managedClusterName,
 			Labels: map[string]string{
-				constants.HoHOperatorOwnerLabelKey: mgh.GetName(),
+				constants.HoHOperatorOwnerLabelKey: constants.HoHOperatorOwnerLabelVal,
 			},
 		},
 		Spec: workv1.ManifestWorkSpec{
@@ -588,7 +588,7 @@ func applyHubHypershiftWorks(ctx context.Context, c client.Client, log logr.Logg
 			Name:      fmt.Sprintf("%s-%s", managedClusterName, constants.HoHHostingHubWorkSuffix),
 			Namespace: hcConfig.HostingClusterName,
 			Labels: map[string]string{
-				constants.HoHOperatorOwnerLabelKey: mgh.GetName(),
+				constants.HoHOperatorOwnerLabelKey: constants.HoHOperatorOwnerLabelVal,
 			},
 		},
 		Spec: workv1.ManifestWorkSpec{
@@ -708,7 +708,7 @@ func applyHoHAgentWork(ctx context.Context, c client.Client, log logr.Logger, mg
 			Name:      fmt.Sprintf("%s-%s", managedClusterName, constants.HoHAgentWorkSuffix),
 			Namespace: managedClusterName,
 			Labels: map[string]string{
-				constants.HoHOperatorOwnerLabelKey: mgh.GetName(),
+				constants.HoHOperatorOwnerLabelKey: constants.HoHOperatorOwnerLabelVal,
 			},
 		},
 		Spec: workv1.ManifestWorkSpec{
@@ -779,7 +779,7 @@ func applyHoHAgentHypershiftWork(ctx context.Context, c client.Client, log logr.
 			Name:      fmt.Sprintf("%s-%s", managedClusterName, constants.HoHHostedAgentWorkSuffix),
 			Namespace: managedClusterName,
 			Labels: map[string]string{
-				constants.HoHOperatorOwnerLabelKey: mgh.GetName(),
+				constants.HoHOperatorOwnerLabelKey: constants.HoHOperatorOwnerLabelVal,
 			},
 		},
 		Spec: workv1.ManifestWorkSpec{
@@ -828,7 +828,7 @@ func applyHoHAgentHypershiftWork(ctx context.Context, c client.Client, log logr.
 			Name:      fmt.Sprintf("%s-%s", managedClusterName, constants.HoHHostingAgentWorkSuffix),
 			Namespace: hcConfig.HostingClusterName,
 			Labels: map[string]string{
-				constants.HoHOperatorOwnerLabelKey: mgh.GetName(),
+				constants.HoHOperatorOwnerLabelKey: constants.HoHOperatorOwnerLabelVal,
 			},
 		},
 		Spec: workv1.ManifestWorkSpec{


### PR DESCRIPTION
ref: https://github.com/stolostron/backlog/issues/25023

According to https://github.com/kubernetes-sigs/controller-runtime/blob/master/pkg/predicate/predicate.go#L140
We should use `GenerationChangedPredicate` if we only want to trigger reconcile when spec changes. @clyang82 

Signed-off-by: morvencao <lcao@redhat.com>