### PR TITLE
rename hub-of-hubs to multicluster-globalhub.

### DIFF
--- a/operator/README.md
+++ b/operator/README.md
@@ -1,12 +1,12 @@
 # multicluster-globalhub-operator
 
-The operator of Hub-of-Hubs (see: https://github.com/stolostron/multicluster-globalhub)
+The operator of multicluster global hub (see: https://github.com/stolostron/multicluster-globalhub)
 
 ## Prerequisites
 
 1. Connect to a Kubernetes cluster with `kubectl`
 2. ACM or OCM is installed on the Kubernetes cluster
-3. PostgreSQL is installed and a database is created for hub-of-hubs, also a secret with name `storage-secret` that contains the credential should be created in `open-cluster-management` namespace. The credential format like `postgres://<user>:<password>@<host>:<port>/<database>`:
+3. PostgreSQL is installed and a database is created for multicluster global hub, also a secret with name `storage-secret` that contains the credential should be created in `open-cluster-management` namespace. The credential format like `postgres://<user>:<password>@<host>:<port>/<database>`:
 
 ```bash
 kubectl create secret generic storage-secret -n "open-cluster-management" \

--- a/operator/bundle/manifests/multicluster-globalhub-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/multicluster-globalhub-operator.clusterserviceversion.yaml
@@ -35,8 +35,8 @@ spec:
       kind: MultiClusterGlobalHub
       name: multiclusterglobalhubs.operator.open-cluster-management.io
       version: v1alpha1
-  description: multicluster-globalhub-operator defines the configuration for the hub-of-hubs
-    installation with one custom resource.
+  description: multicluster-globalhub-operator defines the configuration for multicluster
+    global hub installation with one custom resource.
   displayName: multicluster-globalhub-operator
   icon:
   - base64data: ""
@@ -921,7 +921,7 @@ spec:
   - supported: true
     type: AllNamespaces
   keywords:
-  - hub-of-hubs
+  - multicluster-globalhub
   - multiple-hubs
   links:
   - name: Hub Of Hubs Operator

--- a/operator/config/manifests/bases/multicluster-globalhub-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/bases/multicluster-globalhub-operator.clusterserviceversion.yaml
@@ -16,8 +16,8 @@ spec:
       kind: MultiClusterGlobalHub
       name: multiclusterglobalhubs.operator.open-cluster-management.io
       version: v1alpha1
-  description: multicluster-globalhub-operator defines the configuration for the hub-of-hubs
-    installation with one custom resource.
+  description: multicluster-globalhub-operator defines the configuration for multicluster
+    global hub installation with one custom resource.
   displayName: multicluster-globalhub-operator
   icon:
   - base64data: ""
@@ -36,7 +36,7 @@ spec:
   - supported: true
     type: AllNamespaces
   keywords:
-  - hub-of-hubs
+  - multicluster-globalhub
   - multiple-hubs
   links:
   - name: Hub Of Hubs Operator

--- a/operator/config/samples/operator_v1alpha1_multiclusterglobalhub.yaml
+++ b/operator/config/samples/operator_v1alpha1_multiclusterglobalhub.yaml
@@ -2,9 +2,9 @@ apiVersion: operator.open-cluster-management.io/v1alpha1
 kind: MultiClusterGlobalHub
 metadata:
   # annotations:
-    # hoh-image-repository: quay.io/open-cluster-management-hub-of-hubs
+    # hoh-image-repository: quay.io/<quay_io_id>
     # hoh-image-tag: latest
-    # hoh-hub_of_hubs_manager-image: quay.io/open-cluster-management-hub-of-hubs/multicluster-globalhub-manager:dev
+    # hoh-hub_of_hubs_manager-image: quay.io/<quay_io_id>/multicluster-globalhub-manager:latest
     # hoh-hub-ACM-snapshot: 2.5.0-SNAPSHOT-2022-05-13-20-43-27
     # hoh-hub-MCE-snapshot: 2.0.0-BACKPLANE-2022-05-13-17-52-12
     # hoh-kafka-bootstrap-server: kafka-brokers-cluster-kafka-external-bootstrap-kafka.apps.testing.example.com

--- a/operator/pkg/condition/condition.go
+++ b/operator/pkg/condition/condition.go
@@ -63,21 +63,21 @@ const (
 const (
 	CONDITION_TYPE_RBAC_DEPLOY    = "RBACDeployed"
 	CONDITION_REASON_RBAC_DEPLOY  = "RBACDeployed"
-	CONDITION_MESSAGE_RBAC_DEPLOY = "Hub-of-Hubs RBAC Deployed"
+	CONDITION_MESSAGE_RBAC_DEPLOY = "Multicluster Global Hub RBAC Deployed"
 )
 
 // NOTE: the status of ManagerDeployed can only be True; otherwise there is no condition
 const (
 	CONDITION_TYPE_MANAGER_DEPLOY    = "ManagerDeployed"
 	CONDITION_REASON_MANAGER_DEPLOY  = "ManagerDeployed"
-	CONDITION_MESSAGE_MANAGER_DEPLOY = "Hub-of-Hubs Manager Deployed"
+	CONDITION_MESSAGE_MANAGER_DEPLOY = "Multicluster Global Hub Manager Deployed"
 )
 
 // NOTE: the status of ConsoleDeployed can only be True; otherwise there is no condition
 const (
 	CONDITION_TYPE_CONSOLE_DEPLOY    = "ConsoleDeployed"
 	CONDITION_REASON_CONSOLE_DEPLOY  = "ConsoleDeployed"
-	CONDITION_MESSAGE_CONSOLE_DEPLOY = "Hub-of-Hubs Console Deployed"
+	CONDITION_MESSAGE_CONSOLE_DEPLOY = "Multicluster Global Hub Console Deployed"
 )
 
 // NOTE: the status of LeafHubDeployed can only be True; otherwise there is no condition

--- a/operator/pkg/constants/constants.go
+++ b/operator/pkg/constants/constants.go
@@ -28,21 +28,23 @@ const (
 	LeafHubClusterDisabledLabelVal           = "disabled"
 	LeafHubClusterAnnotationKey              = "hub-of-hubs.open-cluster-management.io/managed-by-hoh"
 	GlobalHubSkipConsoleInstallAnnotationKey = "globalhub.open-cluster-management.io/skip-console-install"
-	HoHOperatorOwnerLabelKey                 = "hub-of-hubs.open-cluster-management.io/managed-by"
+	HoHOperatorOwnerLabelKey                 = "globalhub.open-cluster-management.io/managed-by"
 	HoHOperatorOwnerLabelVal                 = "multicluster-globalhub-operator"
-	HoHOperatorFinalizer                     = "hub-of-hubs.open-cluster-management.io/res-cleanup"
+	HoHOperatorFinalizer                     = "globalhub.open-cluster-management.io/res-cleanup"
 
 	LeafHubClusterInstallHubLabelKey        = "globalhub.open-cluster-management.io/hub-install"
 	LeafHubClusterDisableInstallHubLabelVal = "disabled"
 )
 
 const (
-	HoHClusterManagementAddonName               = "multicluster-globalhub-controller"
-	HoHClusterManagementAddonDisplayName        = "Hub of Hubs Controller"
-	HoHClusterManagementAddonDescription        = "Hub of Hubs Controller manages hub-of-hubs components."
-	HoHManagedClusterAddonName                  = "multicluster-globalhub-controller"
-	HoHManagedClusterAddonDisplayName           = "Hub of Hubs Controller"
-	HoHManagedClusterAddonDescription           = "Hub of Hubs Controller manages hub-of-hubs components."
+	HoHClusterManagementAddonName        = "multicluster-globalhub-controller"
+	HoHClusterManagementAddonDisplayName = "Multicluster Global Hub Controller"
+	HoHClusterManagementAddonDescription = "Multicluster Global Hub Controller " +
+		"manages multicluster-globalhub components."
+	HoHManagedClusterAddonName        = "multicluster-globalhub-controller"
+	HoHManagedClusterAddonDisplayName = "Multicluster Global Hub Controller"
+	HoHManagedClusterAddonDescription = "Multicluster Global Hub Controller " +
+		"manages multicluster-globalhub components."
 	HoHManagedClusterAddonInstallationNamespace = "open-cluster-management"
 )
 

--- a/operator/pkg/controllers/hubofhubs/manifests/console-cleanup/hoh-console-cleanup.yaml
+++ b/operator/pkg/controllers/hubofhubs/manifests/console-cleanup/hoh-console-cleanup.yaml
@@ -1,10 +1,10 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: hoh-of-hubs-console-cleanup
+  name: multicluster-globalhub-console-cleanup
   namespace: open-cluster-management
   labels:
-    name: hoh-of-hubs-console
+    name: multicluster-globalhub-console
 spec:
   template:
     spec:
@@ -24,6 +24,6 @@ spec:
       volumes:
       - name: console-script
         configMap:
-          name: hoh-of-hubs-console-script
+          name: multicluster-globalhub-console-script
           defaultMode: 0755
       restartPolicy: Never

--- a/operator/pkg/controllers/hubofhubs/manifests/console-setup/hoh-console-script.yaml
+++ b/operator/pkg/controllers/hubofhubs/manifests/console-setup/hoh-console-script.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name:  hoh-of-hubs-console-script
+  name:  multicluster-globalhub-console-script
   namespace: open-cluster-management
   labels:
-    name: hoh-of-hubs-console
+    name: multicluster-globalhub-console
 data:
   console-setup.sh: |
     #!/bin/bash

--- a/operator/pkg/controllers/hubofhubs/manifests/console-setup/hoh-console-setup.yaml
+++ b/operator/pkg/controllers/hubofhubs/manifests/console-setup/hoh-console-setup.yaml
@@ -1,10 +1,10 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: hoh-of-hubs-console-setup
+  name: multicluster-globalhub-console-setup
   namespace: open-cluster-management
   labels:
-    name: hoh-of-hubs-console
+    name: multicluster-globalhub-console
 spec:
   template:
     spec:
@@ -24,6 +24,6 @@ spec:
       volumes:
       - name: console-script
         configMap:
-          name: hoh-of-hubs-console-script
+          name: multicluster-globalhub-console-script
           defaultMode: 0755
       restartPolicy: Never

--- a/operator/pkg/controllers/leafhub/addon.go
+++ b/operator/pkg/controllers/leafhub/addon.go
@@ -32,7 +32,7 @@ import (
 	"github.com/stolostron/multicluster-globalhub/operator/pkg/constants"
 )
 
-// applyClusterManagementAddon creates or updates ClusterManagementAddOn for hub-of-hubs
+// applyClusterManagementAddon creates or updates ClusterManagementAddOn for multicluster-globalhub
 func applyClusterManagementAddon(ctx context.Context, c client.Client, log logr.Logger) error {
 	newHoHClusterManagementAddOn := buildClusterManagementAddon()
 	existingHoHClusterManagementAddOn := &addonv1alpha1.ClusterManagementAddOn{}
@@ -62,7 +62,7 @@ func applyClusterManagementAddon(ctx context.Context, c client.Client, log logr.
 	return nil
 }
 
-// deleteClusterManagementAddon deletes ClusterManagementAddOn for hub-of-hubs
+// deleteClusterManagementAddon deletes ClusterManagementAddOn for multicluster-globalhub
 func deleteClusterManagementAddon(ctx context.Context, c client.Client, log logr.Logger) error {
 	hohClusterManagementAddOn := buildClusterManagementAddon()
 	err := c.Delete(ctx, hohClusterManagementAddOn)
@@ -75,7 +75,7 @@ func deleteClusterManagementAddon(ctx context.Context, c client.Client, log logr
 	return nil
 }
 
-// buildClusterManagementAddon builds ClusterManagementAddOn resource for hub-of-hubs
+// buildClusterManagementAddon builds ClusterManagementAddOn resource for multicluster-globalhub
 func buildClusterManagementAddon() *addonv1alpha1.ClusterManagementAddOn {
 	return &addonv1alpha1.ClusterManagementAddOn{
 		ObjectMeta: metav1.ObjectMeta{

--- a/operator/pkg/controllers/leafhub/leafhub_controller.go
+++ b/operator/pkg/controllers/leafhub/leafhub_controller.go
@@ -386,7 +386,8 @@ func (r *LeafHubReconciler) reconcileHostedLeafHub(ctx context.Context, log logr
 		}
 	}
 
-	isChannelServiceReady, channelServiceIP := findStatusFeedbackValueFromWork(hubMgtWork, "Service", "clusterIP", "", log)
+	isChannelServiceReady, channelServiceIP :=
+		findStatusFeedbackValueFromWork(hubMgtWork, "Service", "clusterIP", "", log)
 	if !isChannelServiceReady {
 		log.Info("channel service is not ready, won't apply the multicluster-globalhub-agent manifestwork")
 		return nil

--- a/operator/pkg/controllers/leafhub/manifests/hypershift/hub/hosting/12-multicluster-globalhub-agent-applier.yaml
+++ b/operator/pkg/controllers/leafhub/manifests/hypershift/hub/hosting/12-multicluster-globalhub-agent-applier.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: hoh-of-hubs-agent-applier
+  name: multicluster-globalhub-agent-applier
   namespace: {{.HostedClusterName}}
 spec:
   template:

--- a/operator/pkg/renderer/hoh_renderer.go
+++ b/operator/pkg/renderer/hoh_renderer.go
@@ -16,7 +16,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/yaml"
 )
 
-// HoHRenderer is an implementation of the Renderer interface for hub-of-hubs scenario
+// HoHRenderer is an implementation of the Renderer interface for multicluster-globalhub scenario
 type HoHRenderer struct {
 	manifestFS embed.FS
 	decoder    runtime.Decoder


### PR DESCRIPTION
follow up PR for https://github.com/stolostron/multicluster-globalhub/pull/131
rename hub-of-hubs to multicluster-globalhub

There are still some need to be renamed, eg.

```
hub-of-hubs.open-cluster-management.io/managed-by-hoh
```

and 

```
hub-of-hubs.open-cluster-management.io/used-by: hub-of-hubs
```

but these remaining ones need to be carefully handled, because console needs the old ones.

Signed-off-by: morvencao <lcao@redhat.com>